### PR TITLE
Implementation of an extended JSON encoder

### DIFF
--- a/modules/encoder.py
+++ b/modules/encoder.py
@@ -1,0 +1,44 @@
+import json
+import datetime
+import pprint
+import PersonalBank as pb
+import Product as pr
+import Transaction as tr
+
+
+class ProductEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, pr.Product):
+            return {
+                "name": obj.name,
+                "price": obj.price
+            }
+        return json.JSONEncoder.default(self, obj)
+
+
+class TransactionEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, tr.Transaction):
+            return {
+                "product list": [ProductEncoder.default(self, p)
+                                 for p in obj.product_list],
+                "environment characteristic": obj.environment_characteristic,
+                "place": obj.place,
+                "date": str(obj.date)
+            }
+        return json.JSONEncoder.default(self, obj)
+
+
+if __name__ == "__main__":
+    p = pr.Product("Beer", 2.5)
+    json_string = json.dumps(p, cls=ProductEncoder)
+
+    pprint.pprint(json.loads(json_string))
+
+    p2 = pr.Product("Pizza", 9.0)
+    t = tr.Transaction([p, p2], "friends", "in", datetime.date.today())
+    json_string = json.dumps(t, cls=TransactionEncoder)
+
+    pprint.pprint(json.loads(json_string))

--- a/modules/encoder.py
+++ b/modules/encoder.py
@@ -1,6 +1,5 @@
 import json
 import datetime
-import pprint
 import PersonalBank as pb
 import Product as pr
 import Transaction as tr
@@ -31,14 +30,35 @@ class TransactionEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+class PersonalBankEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, pb.PersonalBank):
+            return {
+                "balance": obj.balance,
+                "history": [TransactionEncoder.default(self, t)
+                            for t in obj.get_transaction_history()]
+            }
+
+
 if __name__ == "__main__":
     p = pr.Product("Beer", 2.5)
-    json_string = json.dumps(p, cls=ProductEncoder)
 
-    pprint.pprint(json.loads(json_string))
+    json_string = json.dumps(p, cls=ProductEncoder, indent=2, sort_keys=True)
+
+    print(json_string)
 
     p2 = pr.Product("Pizza", 9.0)
     t = tr.Transaction([p, p2], "friends", "in", datetime.date.today())
-    json_string = json.dumps(t, cls=TransactionEncoder)
 
-    pprint.pprint(json.loads(json_string))
+    json_string = json.dumps(t, cls=TransactionEncoder,
+                             indent=2, sort_keys=True)
+
+    print(json_string)
+
+    personal_bank = pb.PersonalBank()
+    personal_bank.add_transaction(t)
+
+    json_string = json.dumps(personal_bank, cls=PersonalBankEncoder,
+                             indent=2, sort_keys=True)
+    print(json_string)


### PR DESCRIPTION
OK, so I've made two encoders actually. One works for Product instances and the other for Transaction instancies. There will be another encoder for PersonalBank instances when that class is implemented.

Essentially, the implementation calls the encoder of the top level and recursively calling encoders for lower level. For example, to encode a Transaction instance the encoder for that instance is called which in turn calls the encoder for every product in the product list.

Here is the testing code:

```python
if __name__ == "__main__":
    p = pr.Product("Beer", 2.5)
    json_string = json.dumps(p, cls=ProductEncoder)

    pprint.pprint(json.loads(json_string))

    p2 = pr.Product("Pizza", 9.0)
    t = tr.Transaction([p, p2], "friends", "in", datetime.date.today())
    json_string = json.dumps(t, cls=TransactionEncoder)

    pprint.pprint(json.loads(json_string))
```

and here is the response:

```
{'name': 'Beer', 'price': 2.5}
{'date': '2018-10-11',
 'environment characteristic': 'friends',
 'place': 'in',
 'product list': [{'name': 'Beer', 'price': 2.5},
                  {'name': 'Pizza', 'price': 9.0}]}
```

notice that both `json.loads()` and `json.dumps()` are called. The former is for reading json strings and the latter for creating them. Hence, the whole cycle of read/write works. There is a catch though...

Loading a json string just makes it a dictionary which means that we still have to convert **that** into instances of the specific classes.