### PR TITLE
Import statement and gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,13 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm project settings
+.idea/
+
+# VSCode project settings
+.vscode/
+
+# Specific files
+*.json
+git-branch-not-on-remote.sh

--- a/cost_management/account.py
+++ b/cost_management/account.py
@@ -1,5 +1,5 @@
-from transaction import Transaction
-from cost_types.base_type import Product
+from .transaction import Transaction
+from .cost_types.base_type import Product
 from datetime import date
 import re
 

--- a/cost_management/transaction.py
+++ b/cost_management/transaction.py
@@ -1,4 +1,4 @@
-from cost_types.base_type import Product
+from .cost_types.base_type import Product
 import datetime
 
 


### PR DESCRIPTION
There was some implications with imports. Imports should not be absolute there for the dot notation is used instead as you can see in `account.py` and `transaction.py`. However, this breaks the ability to run the file as a standalone to test it. Therefore, we should have a official testing environment which will be explained in another issue. 

For the mean time if you want to test something, you should create a file in the root directory of the project and test each module there.

I also added a few more lines in `.gitignore` so as to have a cleaner `git status` command.